### PR TITLE
Add platform flag to make `toolchain.tar`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ $(OUT_DIR)/toolchain.tar:
 		--build-arg CARGO_REF=$(CARGO_REF) \
 		--build-arg CONFIG_DIR=$(CONFIG_DIR) \
 		--build-arg SCRIPTS_DIR=$(SRC_DIR)/toolchain/scripts \
+		--platform=linux/$(ARCH) \
 		-f $(SRC_DIR)/toolchain/Dockerfile \
 		.
 	docker save "local/$(NAME)-build" -o "$@"


### PR DESCRIPTION
This PR adds the `--platform` flag to the docker build command for making toolchain.tar. This should ensure that toolchain.tart is built for the target platform regardless of the build host's platform.